### PR TITLE
[chore] improve mysql cluster node handling, version pinning, and firewall config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-# Created by https://www.toptal.com/developers/gitignore/api/ansible,intellij+all
-# Edit at https://www.toptal.com/developers/gitignore?templates=ansible,intellij+all
-
 ### Ansible ###
 *.retry
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,93 @@
+# Created by https://www.toptal.com/developers/gitignore/api/ansible,intellij+all
+# Edit at https://www.toptal.com/developers/gitignore?templates=ansible,intellij+all
+
+### Ansible ###
+*.retry
+
+### Intellij+all ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# AWS User-specific
+.idea/**/aws.xml
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# SonarLint plugin
+.idea/sonarlint/
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### Intellij+all Patch ###
+# Ignore everything but code style settings and run configurations
+# that are supposed to be shared within teams.
+
+.idea/*
+
+!.idea/codeStyles
+!.idea/runConfigurations

--- a/README.md
+++ b/README.md
@@ -24,12 +24,15 @@ No special requirements; note that this role requires root access, so either run
 Available variables are listed below, along with default values (see `defaults/main.yml`):
 
 ```plaintext
-mysql_version: 8.0.43 
+mysql_version: 8.0
 configure_ssl_connection: true
 firewall_enabled: true
 firewall_port:
   - 3306
   - 3307
+  - 33060
+  - 33061
+
 
 # Required params:
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ At the moment, the cluster is running in `**"topologyMode": "Single-Primary"**`,
 Example Playbook
 ----------------
 
-requiremets.yml:
+requirements.yml:
 
 ```plauntext
 - src: git@github.com:AleksFirsta/ansible-role-mysql-cluster.git

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,8 @@ firewall_enabled: true
 firewall_port:
   - 3306
   - 3307
+  - 33060
+  - 33061
 
 # Required params:
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # defaults file for mysql-cluster
-mysql_version: 8.0.44
+mysql_version: 8.0 # !!! locking is to major-versions only
 
 configure_ssl_connection: true
 
@@ -12,7 +12,6 @@ firewall_port:
   - 33061
 
 # Required params:
-
 mysql_root_pass: ''
 mysql_cluster_name: ''
 mysql_cluster_admin_user: ''

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # defaults file for mysql-cluster
-mysql_version: 8.0 # !!! locking is to major-versions only
+mysql_version: 8.0 # !!! locking is to major versions only
 
 configure_ssl_connection: true
 

--- a/files/inno_db_setup.js
+++ b/files/inno_db_setup.js
@@ -7,6 +7,7 @@ let port = os.getenv('PORT');
 let action = os.getenv('ACTION') || "";
 let clusterName = os.getenv('CLUSTER_NAME') || "mysql-cluster";
 let mysqlHost = os.getenv('MYSQL_HOST') || "";
+let mysqlHostAddress = os.getenv('MYSQL_HOST_ADDRESS') || "";
 let topologyMode = os.getenv('TOPOLOGY_MODE') || "";
 
 
@@ -127,16 +128,18 @@ if (action === "addNodes") {
   try {
     let cluster = dba.getCluster();
     let status = cluster.status();
+    let targetHost = mysqlHostAddress || mysqlHost;
 
-    if (isHostInCluster(status, mysqlHost)) {
-      print(`Instance '${mysqlHost}' is already part of the cluster '${cluster.getName()}'. Skipping.\n`);
+    if (isHostInCluster(status, targetHost)) {
+      print(`Instance '${targetHost}' is already part of the cluster '${cluster.getName()}'. Skipping.\n`);
     } else {
-      print(`Adding instance '${mysqlHost}' to the cluster...\n`);
-      cluster.addInstance(mysqlHost, {
+      print(`Adding instance '${targetHost}' to the cluster...\n`);
+      let nodeUri = `${user}:${encodeURIComponent(password)}@${targetHost}:${port}`;
+      cluster.addInstance(nodeUri, {
         recoveryMethod: 'clone',
         interactive: false
       });
-      print(`Instance '${mysqlHost}' added successfully.\n`);
+      print(`Instance '${targetHost}' added successfully.\n`);
     }
   } catch(err) {
     print("Unexpected error during addNodes action: " + err.message + "\n");

--- a/files/inno_db_setup.js
+++ b/files/inno_db_setup.js
@@ -93,7 +93,7 @@ if (config.status === "ok") {
     interactive: false,
     restart: true
   }).then(session => {
-    print("Instance succesufully configured\n", session);
+    print("Instance successfully configured\n", session);
   }).catch(err => {
     print("error to configure instance\n", err);
   });

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,8 +4,3 @@
   ansible.builtin.service:
     name: "{{ 'mysqld' if ansible_os_family == 'RedHat' else 'mysql' }}"
     state: restarted
-
-- name: Refresh package facts
-  ansible.builtin.package_facts:
-    manager: auto
-

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,3 +4,8 @@
   ansible.builtin.service:
     name: "{{ 'mysqld' if ansible_os_family == 'RedHat' else 'mysql' }}"
     state: restarted
+
+- name: Refresh package facts
+  ansible.builtin.package_facts:
+    manager: auto
+

--- a/tasks/change_temp_pass_mysql.yml
+++ b/tasks/change_temp_pass_mysql.yml
@@ -44,7 +44,8 @@
     '{{ mysql_temp_password }}'
     -e "ALTER USER 'root'@'localhost' IDENTIFIED BY '{{ mysql_root_pass }}';"
   when:
-    - mysql_check_pass.rc != 0 and ansible_os_family == "Debian"
+    - mysql_check_pass.rc != 0
+    - ansible_os_family == "Debian"
   args:
     executable: /bin/bash
   register: mysql_root_pass_change

--- a/tasks/change_temp_pass_mysql.yml
+++ b/tasks/change_temp_pass_mysql.yml
@@ -24,7 +24,7 @@
   changed_when: false
   failed_when: false
 
-- name: Change MySQL root password RHEL
+- name: Change MySQL root password on {{ ansible_os_family }} systems
   ansible.builtin.shell: >
     sudo mysql -uroot -p'{{mysql_temp_password[0]}}'
     --connect-expired-password
@@ -38,7 +38,7 @@
   changed_when: "'ERROR' not in mysql_root_pass_change.stderr"
   failed_when: "'ERROR' in mysql_root_pass_change.stderr"
 
-- name: Change MySQL root password UBUNTU
+- name: Change MySQL root password on {{ ansible_os_family }} systems
   ansible.builtin.shell: >
     sudo mysql -uroot -p
     '{{ mysql_temp_password }}'

--- a/tasks/config_etc_hosts.yml
+++ b/tasks/config_etc_hosts.yml
@@ -1,7 +1,7 @@
 - name: Add all mysql hosts to /etc/hosts
   ansible.builtin.lineinfile: 
     path: /etc/hosts
-    line: "{{ item }} {{ hostvars[item].ansible_hostname }}"
+    line: "{{ hostvars[item]['ansible_host'] | default(item) }} {{ hostvars[item].ansible_hostname }}"
     state: present
   loop: "{{ ansible_play_hosts }}"
   become: true

--- a/tasks/install_community_server.yml
+++ b/tasks/install_community_server.yml
@@ -1,11 +1,20 @@
 - name: Install MySQL server on Debian family
   ansible.builtin.apt:
     name: 
-      - "mysql-server={{ mysql_version }}-1ubuntu{{ ansible_distribution_version }}"
+      - "mysql-community-server={{ mysql_version }}"
       - mysql-shell
     state: present
     update_cache: yes
   when: ansible_os_family == "Debian"
+
+- name: Install MySQL server on Ubuntu family
+  ansible.builtin.apt:
+    name: 
+      - "mysql-community-server={{ mysql_version }}"
+      - mysql-shell
+    state: present
+    update_cache: yes
+  when: ansible_os_family == "Ubuntu"  
 
 - name: Install MySQL packages on RedHat family
   ansible.builtin.yum:

--- a/tasks/install_community_server.yml
+++ b/tasks/install_community_server.yml
@@ -1,7 +1,7 @@
 - name: Install MySQL server on Debian family
   ansible.builtin.apt:
     name: 
-      - "mysql-server={{ mysql_version }}"
+      - "mysql-server={{ mysql_version }}*"
       - mysql-shell
     state: present
     update_cache: yes
@@ -10,16 +10,16 @@
 - name: Install MySQL server on Ubuntu family
   ansible.builtin.apt:
     name: 
-      - "mysql-server={{ mysql_version }}"
+      - "mysql-server={{ mysql_version }}*"
       - mysql-shell
     state: present
     update_cache: yes
-  when: ansible_os_family == "Ubuntu"  
+  when: ansible_os_family == "Ubuntu"
 
 - name: Install MySQL packages on RedHat family
   ansible.builtin.yum:
     name:
-      - "mysql-community-server-{{ mysql_version }}"
+      - "mysql-community-server-{{ mysql_version }}*"
       - mysql-shell
     state: present
   when: ansible_os_family == "RedHat"

--- a/tasks/install_community_server.yml
+++ b/tasks/install_community_server.yml
@@ -1,4 +1,4 @@
-- name: Install MySQL server on Debian family
+- name: Install MySQL server on {{ ansible_os_family }} family
   ansible.builtin.apt:
     name: 
       - "mysql-server={{ mysql_version }}*"
@@ -7,16 +7,7 @@
     update_cache: yes
   when: ansible_os_family == "Debian"
 
-- name: Install MySQL server on Ubuntu family
-  ansible.builtin.apt:
-    name: 
-      - "mysql-server={{ mysql_version }}*"
-      - mysql-shell
-    state: present
-    update_cache: yes
-  when: ansible_os_family == "Ubuntu"
-
-- name: Install MySQL packages on RedHat family
+- name: Install MySQL packages on {{ ansible_os_family }} family
   ansible.builtin.yum:
     name:
       - "mysql-community-server-{{ mysql_version }}*"

--- a/tasks/install_community_server.yml
+++ b/tasks/install_community_server.yml
@@ -19,7 +19,7 @@
 - name: Install MySQL packages on RedHat family
   ansible.builtin.yum:
     name:
-      - "mysql-community-server-{{ mysql_version }}-1.el{{ ansible_distribution_major_version }}"
+      - "mysql-community-server-{{ mysql_version }}"
       - mysql-shell
     state: present
   when: ansible_os_family == "RedHat"

--- a/tasks/install_community_server.yml
+++ b/tasks/install_community_server.yml
@@ -1,18 +1,36 @@
-- name: Install MySQL server on {{ ansible_os_family }} family
+- name: Update APT cache
   ansible.builtin.apt:
-    name: 
+    update_cache: yes
+    cache_valid_time: 3600
+  register: apt_update
+  retries: 3
+  delay: 30
+  until: apt_update is success
+  when: ansible_os_family == "Debian"
+
+- name: Install MySQL server on Debian family
+  ansible.builtin.apt:
+    name:
       - "mysql-server={{ mysql_version }}*"
       - mysql-shell
     state: present
-    update_cache: yes
+    update_cache: no
+  register: apt_install
+  retries: 5
+  delay: 60
+  until: apt_install is success
   when: ansible_os_family == "Debian"
 
-- name: Install MySQL packages on {{ ansible_os_family }} family
+- name: Install MySQL packages on RedHat family
   ansible.builtin.yum:
     name:
       - "mysql-community-server-{{ mysql_version }}*"
       - mysql-shell
     state: present
+  register: yum_install
+  retries: 5
+  delay: 60
+  until: yum_install is success
   when: ansible_os_family == "RedHat"
 
 - name: Install PyMySQL for Python3 on Debian-based systems

--- a/tasks/install_community_server.yml
+++ b/tasks/install_community_server.yml
@@ -1,7 +1,7 @@
 - name: Install MySQL server on Debian family
   ansible.builtin.apt:
     name: 
-      - "mysql-community-server={{ mysql_version }}"
+      - "mysql-server={{ mysql_version }}"
       - mysql-shell
     state: present
     update_cache: yes
@@ -10,7 +10,7 @@
 - name: Install MySQL server on Ubuntu family
   ansible.builtin.apt:
     name: 
-      - "mysql-community-server={{ mysql_version }}"
+      - "mysql-server={{ mysql_version }}"
       - mysql-shell
     state: present
     update_cache: yes

--- a/tasks/install_repo_Debian.yml
+++ b/tasks/install_repo_Debian.yml
@@ -18,7 +18,9 @@
     deb: /tmp/mysql-apt-config.deb
   environment:
     DEBIAN_FRONTEND: noninteractive
-  when: ansible_os_family == "Debian"
+  when:
+    - ansible_os_family == "Debian"
+    - "'mysql-apt-config' not in ansible_facts.packages"
 
 - name: Update apt cache
   ansible.builtin.apt:

--- a/tasks/mysql_cluster_creation.yml
+++ b/tasks/mysql_cluster_creation.yml
@@ -90,10 +90,12 @@
     PASSWORD: "{{ mysql_cluster_admin_pass | default(mysql_root_pass) }}"
     HOST: "{{ ansible_host | default(inventory_hostname) }}"
     PORT: "3306"
+    ACTION: "addNodes"
+    MYSQL_HOST: "{{item}}"
     TOPOLOGY_MODE: "{{ mysql_topology_type | default('') }}"
+
+  loop: "{{ non_bootstrap_nodes }}"
   when: mysql_topology_type is defined and is_bootstrap_node
-
-
 
 
 

--- a/tasks/mysql_cluster_creation.yml
+++ b/tasks/mysql_cluster_creation.yml
@@ -44,7 +44,7 @@
   environment:
     USER: "{{mysql_cluster_admin_user}}"
     PASSWORD: "{{mysql_cluster_admin_pass | default(mysql_root_pass)}}"
-    HOST: "{{ inventory_hostname }}"
+    HOST: "{{ ansible_host | default(inventory_hostname) }}"
     PORT: "3306"
 
 - name: MySQL Cluster - Create cluster
@@ -52,7 +52,7 @@
   environment:
     USER: "{{mysql_cluster_admin_user}}"
     PASSWORD: "{{mysql_cluster_admin_pass | default(mysql_root_pass)}}"
-    HOST: "{{ inventory_hostname }}"
+    HOST: "{{ ansible_host | default(inventory_hostname) }}"
     PORT: "3306"
     CLUSTER_NAME: "{{ mysql_cluster_name }}"
     ACTION: "createCluster"
@@ -63,16 +63,23 @@
   ansible.builtin.set_fact:
     non_bootstrap_nodes: "{{ ansible_play_hosts | difference([ansible_play_hosts[0]]) }}"
 
+- name: Build host address mapping
+  ansible.builtin.set_fact:
+    host_addresses: "{{ host_addresses | default({}) | combine({item: hostvars[item]['ansible_host'] | default(item)}) }}"
+  loop: "{{ ansible_play_hosts }}"
+  when: is_bootstrap_node
+
 
 - name: MySQL Cluster - Add nodes
   ansible.builtin.command: mysqlsh -f /tmp/inno_db_setup.js
   environment:
     USER: "{{ mysql_cluster_admin_user }}"
     PASSWORD: "{{ mysql_cluster_admin_pass | default(mysql_root_pass) }}"
-    HOST: "{{ inventory_hostname }}"
+    HOST: "{{ ansible_host | default(inventory_hostname) }}"
     PORT: "3306"
     ACTION: "addNodes"
-    MYSQL_HOST: "{{item}}"
+    MYSQL_HOST: "{{ item }}"
+    MYSQL_HOST_ADDRESS: "{{ host_addresses[item] }}"
   loop: "{{ non_bootstrap_nodes }}"
   when: is_bootstrap_node
 
@@ -81,13 +88,9 @@
   environment:
     USER: "{{ mysql_cluster_admin_user }}"
     PASSWORD: "{{ mysql_cluster_admin_pass | default(mysql_root_pass) }}"
-    HOST: "{{ inventory_hostname }}"
+    HOST: "{{ ansible_host | default(inventory_hostname) }}"
     PORT: "3306"
-    ACTION: "addNodes"
-    MYSQL_HOST: "{{item}}"
     TOPOLOGY_MODE: "{{ mysql_topology_type | default('') }}"
-  
-  loop: "{{ non_bootstrap_nodes }}"
   when: mysql_topology_type is defined and is_bootstrap_node
 
 

--- a/tasks/mysql_cluster_creation.yml
+++ b/tasks/mysql_cluster_creation.yml
@@ -97,6 +97,19 @@
   loop: "{{ non_bootstrap_nodes }}"
   when: mysql_topology_type is defined and is_bootstrap_node
 
+- name: Rescan cluster metadata
+  community.mysql.mysql_shell:
+    login_user: "{{ mysql_cluster_admin_user }}"
+    login_password: "{{ mysql_cluster_admin_pass }}"
+    login_host: "{{ groups['mysql_hosts'][0] }}"
+    login_port: 3306
+    script: |
+      var cluster = dba.getCluster("{{ mysql_cluster_name }}");
+      print("Rescanning cluster metadata...");
+      cluster.rescan();
+      print(cluster.status());
+  run_once: true
+  delegate_to: "{{ groups['mysql_hosts'][0] }}"
 
 
 

--- a/tasks/security_config.yml
+++ b/tasks/security_config.yml
@@ -11,6 +11,13 @@
     replace: 'SELINUX=permissive'
   when: ansible_os_family == "RedHat"
 
+- name: Gather package facts for firewall configuration for {{ansible_os_family}}
+  ansible.builtin.package_facts:
+    manager: auto
+  when:  
+    - ansible_os_family == "Debian"
+    - firewall_enabled
+
 - name: Configuration SSH port for firewall for {{ansible_os_family}}
   ansible.builtin.ufw:
     rule: allow
@@ -20,6 +27,7 @@
   when:
     - ansible_os_family == "Debian"
     - firewall_enabled
+    - "'ufw' in ansible_facts.packages"
 
 - name: Configuration ports for firewall for {{ansible_os_family}}
   ansible.builtin.ufw:
@@ -31,6 +39,7 @@
   when:
     - ansible_os_family == "Debian"
     - firewall_enabled
+    - "'ufw' in ansible_facts.packages"
 
 - name: Configuration ports for firewall for {{ ansible_os_family }}
   ansible.builtin.firewalld:

--- a/tasks/security_config.yml
+++ b/tasks/security_config.yml
@@ -18,6 +18,16 @@
     - ansible_os_family == "Debian"
     - firewall_enabled
 
+- name: Install UFW if missing on Debian systems
+  ansible.builtin.apt:
+    name: ufw
+    state: present
+    update_cache: yes
+  when:
+    - ansible_os_family == "Debian"
+    - firewall_enabled
+    - "'ufw' not in ansible_facts.packages"
+
 - name: Configuration SSH port for firewall for {{ansible_os_family}}
   ansible.builtin.ufw:
     rule: allow
@@ -27,7 +37,6 @@
   when:
     - ansible_os_family == "Debian"
     - firewall_enabled
-    - "'ufw' in ansible_facts.packages"
 
 - name: Configuration ports for firewall for {{ansible_os_family}}
   ansible.builtin.ufw:
@@ -39,7 +48,6 @@
   when:
     - ansible_os_family == "Debian"
     - firewall_enabled
-    - "'ufw' in ansible_facts.packages"
 
 - name: Configuration ports for firewall for {{ ansible_os_family }}
   ansible.builtin.firewalld:

--- a/tasks/security_config.yml
+++ b/tasks/security_config.yml
@@ -14,7 +14,7 @@
 - name: Gather package facts for firewall configuration for {{ansible_os_family}}
   ansible.builtin.package_facts:
     manager: auto
-  when:  
+  when:
     - ansible_os_family == "Debian"
     - firewall_enabled
 

--- a/tasks/security_config.yml
+++ b/tasks/security_config.yml
@@ -11,12 +11,11 @@
     replace: 'SELINUX=permissive'
   when: ansible_os_family == "RedHat"
 
-- name: Gather package facts for firewall configuration for {{ansible_os_family}}
+- name: Gather package facts for {{ansible_os_family}}
   ansible.builtin.package_facts:
     manager: auto
   when:
     - ansible_os_family == "Debian"
-    - firewall_enabled
 
 - name: Install UFW if missing on {{ ansible_os_family }} systems
   ansible.builtin.apt:

--- a/tasks/security_config.yml
+++ b/tasks/security_config.yml
@@ -18,7 +18,7 @@
     - ansible_os_family == "Debian"
     - firewall_enabled
 
-- name: Install UFW if missing on Debian systems
+- name: Install UFW if missing on {{ ansible_os_family }} systems
   ansible.builtin.apt:
     name: ufw
     state: present


### PR DESCRIPTION
This pull request introduces several improvements and fixes to the MySQL cluster Ansible role, focusing on enhanced configurability, improved cluster node management, and better cross-platform support. The most notable changes are grouped below by theme.

**Cluster Node Management & Address Handling:**

* Added support for specifying both `MYSQL_HOST` and `MYSQL_HOST_ADDRESS` when adding nodes, ensuring correct host address resolution and usage in cluster operations (`tasks/mysql_cluster_creation.yml`, `files/inno_db_setup.js`).
* Improved logic in `inno_db_setup.js` to use the resolved host address and properly build the node URI for cluster addition.

**Configurability & Defaults:**

* Changed `mysql_version` to only lock to the major version (e.g., `8.0`) in both documentation and defaults, allowing for more flexible minor/patch upgrades (`README.md`, `defaults/main.yml`).
* Expanded default firewall port list to include 33060 and 33061 for additional MySQL services (`README.md`, `defaults/main.yml`).

**Cross-Platform & Installation Improvements:**

* Generalized package installation and password change task names to be OS-family agnostic and improved package selection patterns for both Debian and RedHat systems (`tasks/install_community_server.yml`, `tasks/change_temp_pass_mysql.yml`).
* Updated host variable usage to prefer `ansible_host` over `inventory_hostname` for better compatibility with inventory setups (`tasks/mysql_cluster_creation.yml`).

**Firewall and Security Enhancements:**

* Added tasks to gather package facts and ensure UFW is installed and configured on Debian systems when the firewall is enabled (`tasks/security_config.yml`, `handlers/main.yml`).

**Minor Fixes:**

* Fixed a typo in a log message in `inno_db_setup.js` ("succesufully" → "successfully").